### PR TITLE
Parser API refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@
   after receiving any attributes to indicate that the start tag
   is fully processed. This was necessary for `StreamParser` to detect
   the stream start tag.
+* `SaxParser` now returns each `SaxElement` as it is parsed via new
+  `SaxElements` lending iterator instead of the clumsy handler trait.
+  Same pattern is used in Document and Stream parsers as well.
+* Since the handler callback is not used anymore, `SaxError` and
+  `DocumentError` which ended up with exact same error variants are
+  consolidated into the `ParseError` object.
 
 ## New features
 
 * Cursor now provides `following_sibling`, `preceding_sibling` iterators.
-* `StreamParser` which turns an XML stream into a sequence of top level
-  elements for stream control tags and stanzas is implemented.
+* New `StreamParser` produces Documents for each XMPP stream top level.
 
 # 0.1.0 (2025-09-06)
 

--- a/src/bin/iksjab.rs
+++ b/src/bin/iksjab.rs
@@ -1,0 +1,49 @@
+/*
+** This file is a part of Iksemel (XML parser for Jabber/XMPP)
+** Copyright (C) 2000-2025 Gurer Ozen
+**
+** Iksemel is free software: you can redistribute it and/or modify it
+** under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of
+** the License, or (at your option) any later version.
+*/
+
+use std::env;
+use std::process::ExitCode;
+
+fn print_version() {
+    println!("iksjab (iksemel) v{}", iks::VERSION);
+}
+
+fn print_usage() {
+    println!(concat!(
+        "Usage: iksjab [OPTIONS]\n",
+        "This tool can communicate over XMPP.\n",
+        "Options:\n",
+        "  -h, --help             Display this help message and exit\n",
+        "  -v, --version          Display the version and exit\n",
+        "Report issues at https://github.com/meduketto/iksemel-rust/issues"
+    ));
+}
+
+fn main() -> ExitCode {
+    let mut args = env::args();
+
+    // Skip the first argument (program name)
+    args.next();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                print_usage();
+                return ExitCode::SUCCESS;
+            }
+            "-v" | "--version" => {
+                print_version();
+                return ExitCode::SUCCESS;
+            }
+            _ => {}
+        }
+    }
+
+    ExitCode::SUCCESS
+}

--- a/src/bin/ikspath.rs
+++ b/src/bin/ikspath.rs
@@ -14,12 +14,10 @@ use std::io::Read;
 use std::io::stdin;
 use std::process::ExitCode;
 
-use iks::{Document, DocumentError, DocumentParser, XPath};
-
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+use iks::{Document, DocumentParser, ParseError, XPath};
 
 fn print_version() {
-    println!("ikspath (iksemel) v{}", VERSION);
+    println!("ikspath (iksemel) v{}", iks::VERSION);
 }
 
 fn print_usage() {
@@ -46,11 +44,11 @@ impl From<std::io::Error> for IkspathError {
     }
 }
 
-impl From<DocumentError> for IkspathError {
-    fn from(err: DocumentError) -> Self {
+impl From<ParseError> for IkspathError {
+    fn from(err: ParseError) -> Self {
         match err {
-            DocumentError::NoMemory => IkspathError::NoMemory,
-            DocumentError::BadXml(msg) => IkspathError::BadXml(msg),
+            ParseError::NoMemory => IkspathError::NoMemory,
+            ParseError::BadXml(msg) => IkspathError::BadXml(msg),
         }
     }
 }

--- a/src/document/error.rs
+++ b/src/document/error.rs
@@ -8,57 +8,17 @@
 ** the License, or (at your option) any later version.
 */
 
-use std::error::Error;
-use std::fmt::Display;
+use crate::{NoMemory, ParseError};
 
-use crate::NoMemory;
-use crate::SaxError;
-
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub enum DocumentError {
-    NoMemory,
-    BadXml(&'static str),
-}
-
-impl Display for DocumentError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DocumentError::NoMemory => write!(f, "not enough memory"),
-            DocumentError::BadXml(msg) => write!(f, "invalid XML syntax: {msg}"),
-        }
-    }
-}
-
-impl Error for DocumentError {}
-
-impl From<SaxError> for DocumentError {
-    fn from(err: SaxError) -> Self {
-        match err {
-            SaxError::NoMemory => DocumentError::NoMemory,
-            SaxError::BadXml(msg) => DocumentError::BadXml(msg),
-            SaxError::HandlerAbort => DocumentError::BadXml(description::UNEXPECTED_HANDLER_ABORT),
-        }
-    }
-}
-
-impl From<DocumentError> for SaxError {
-    fn from(err: DocumentError) -> Self {
-        match err {
-            DocumentError::NoMemory => SaxError::NoMemory,
-            DocumentError::BadXml(msg) => SaxError::BadXml(msg),
-        }
-    }
-}
-
-impl From<NoMemory> for DocumentError {
+impl From<NoMemory> for ParseError {
     fn from(_: NoMemory) -> Self {
-        DocumentError::NoMemory
+        ParseError::NoMemory
     }
 }
 
 pub(super) mod description {
-    pub(super) const UNEXPECTED_HANDLER_ABORT: &str = "unexpected handler abort";
     pub(in super::super) const NO_DOCUMENT: &str = "no document parsed yet";
+    pub(in super::super) const NO_START_TAG: &str = "document must start with a StartTag element";
     pub(in super::super) const TAG_MISMATCH: &str = "start and end tags have different names";
     pub(in super::super) const DUPLICATE_ATTRIBUTE: &str =
         "attribute name already used in this tag";

--- a/src/document/tests.rs
+++ b/src/document/tests.rs
@@ -58,16 +58,16 @@ fn attributes() {
     assert!(a.insert_attribute("i", "1").unwrap().is_tag());
     assert_eq!(
         a.insert_attribute("i", "1").unwrap_err(),
-        DocumentError::BadXml(description::DUPLICATE_ATTRIBUTE)
+        ParseError::BadXml(description::DUPLICATE_ATTRIBUTE)
     );
     assert!(a.insert_attribute("j", "2").unwrap().is_tag());
     assert_eq!(
         a.insert_attribute("i", "1").unwrap_err(),
-        DocumentError::BadXml(description::DUPLICATE_ATTRIBUTE)
+        ParseError::BadXml(description::DUPLICATE_ATTRIBUTE)
     );
     assert_eq!(
         a.insert_attribute("j", "1").unwrap_err(),
-        DocumentError::BadXml(description::DUPLICATE_ATTRIBUTE)
+        ParseError::BadXml(description::DUPLICATE_ATTRIBUTE)
     );
     let _ = doc
         .insert_tag("b")
@@ -283,18 +283,18 @@ fn null_checks() {
 fn bad_doc_parser() {
     assert_eq!(
         Document::from_str("<a>lala</b>").err(),
-        Some(DocumentError::BadXml(TAG_MISMATCH))
+        Some(ParseError::BadXml(TAG_MISMATCH))
     );
     assert_eq!(
         Document::from_str("<a><b><c/></d></a>").err(),
-        Some(DocumentError::BadXml(TAG_MISMATCH))
+        Some(ParseError::BadXml(TAG_MISMATCH))
     );
     assert_eq!(
         Document::from_str("<a><b><c/></b><d></d><e></e2></a>").err(),
-        Some(DocumentError::BadXml(TAG_MISMATCH))
+        Some(ParseError::BadXml(TAG_MISMATCH))
     );
     assert_eq!(
         Document::from_str("<a><b x=\"1\" y=\"2\" x=\"abc\"/></a>").err(),
-        Some(DocumentError::BadXml(DUPLICATE_ATTRIBUTE))
+        Some(ParseError::BadXml(DUPLICATE_ATTRIBUTE))
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,10 @@
 //! It validates and processes byte streams and generates XML elements.
 //!
 //! See:
-//! [SaxError],
+//! [ParseError],
 //! [SaxParser],
 //! [SaxElement],
-//! [SaxHandler],
+//! [SaxElements],
 //! [Location]
 //!
 //! # Arena
@@ -71,7 +71,7 @@
 //! parse an XML byte stream into an XML element tree structure.
 //!
 //! See:
-//! [DocumentError],
+//! [DocumentBuilder],
 //! [DocumentParser]
 //!
 //! # Stream Parser
@@ -96,14 +96,16 @@ mod parser;
 mod xmpp;
 mod xpath;
 
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub use arena::Arena;
 pub use arena::ArenaStats;
 pub use arena::NoMemory;
 
 pub use parser::Location;
+pub use parser::ParseError;
 pub use parser::SaxElement;
-pub use parser::SaxError;
-pub use parser::SaxHandler;
+pub use parser::SaxElements;
 pub use parser::SaxParser;
 
 pub use document::Attributes;
@@ -112,15 +114,11 @@ pub use document::Cursor;
 pub use document::DescendantOrSelf;
 pub use document::Document;
 pub use document::DocumentBuilder;
-pub use document::DocumentError;
 pub use document::DocumentParser;
 pub use document::FollowingSibling;
 pub use document::PrecedingSibling;
 
-pub use xmpp::ClientStream;
-pub use xmpp::ClientStreamHandler;
 pub use xmpp::StreamError;
-pub use xmpp::StreamHandler;
 pub use xmpp::StreamParser;
 
 pub use xpath::XPath;

--- a/src/xmpp/client.rs
+++ b/src/xmpp/client.rs
@@ -7,14 +7,3 @@
 ** published by the Free Software Foundation, either version 3 of
 ** the License, or (at your option) any later version.
 */
-
-mod client;
-mod constants;
-mod error;
-mod parser;
-
-pub use error::StreamError;
-pub use parser::StreamParser;
-
-#[cfg(test)]
-mod tests;

--- a/src/xmpp/error.rs
+++ b/src/xmpp/error.rs
@@ -11,7 +11,7 @@
 use std::error::Error;
 use std::fmt::Display;
 
-use crate::SaxError;
+use crate::ParseError;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum StreamError {
@@ -32,12 +32,11 @@ impl Display for StreamError {
 
 impl Error for StreamError {}
 
-impl From<SaxError> for StreamError {
-    fn from(err: SaxError) -> Self {
+impl From<ParseError> for StreamError {
+    fn from(err: ParseError) -> Self {
         match err {
-            SaxError::NoMemory => StreamError::NoMemory,
-            SaxError::BadXml(msg) => StreamError::BadXml(msg),
-            SaxError::HandlerAbort => StreamError::BadXml("Unexpected handler abort"),
+            ParseError::NoMemory => StreamError::NoMemory,
+            ParseError::BadXml(msg) => StreamError::BadXml(msg),
         }
     }
 }


### PR DESCRIPTION
* `SaxElement::EmptyElementTag` is replaced with `StartTagEmpty`, and a new `StartTagContent` element is added. Now you get one of these after receiving any attributes to indicate that the start tag is fully processed. This was necessary for `StreamParser` to detect the stream start tag.
* `SaxParser` now returns each `SaxElement` as it is parsed via new `SaxElements` lending iterator instead of the clumsy handler trait. Same pattern is used in Document and Stream parsers as well.
* Since the handler callback is not used anymore, `SaxError` and `DocumentError` which ended up with exact same error variants are consolidated into the `ParseError` object.
* New `StreamParser` produces Documents for each XMPP stream top level.