### PR TITLE
do not expose rustls types directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.7.0 (TBD)
 
-* XmppClientError no longer expose the rustls::Error in the type
+* XmppClientError no longer exposes rustls::Error in its type
   to avoid forcing callers to add Rustls as a direct dependency.
 
 # 0.6.0 (2026-04-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 0.6.1 (TBD)
+# 0.7.0 (TBD)
+
+* XmppClientError no longer expose the rustls::Error in the type
+  to avoid forcing callers to add Rustls as a direct dependency.
 
 # 0.6.0 (2026-04-20)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "iks"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "base64",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["xml", "xmpp", "jabber", "parser"]
 license = "LGPL-3.0-or-later"
 name = "iks"
 repository = "https://github.com/meduketto/iksemel-rust"
-version = "0.6.1"
+version = "0.7.0"
 
 [features]
 default = ["xmpp"]

--- a/src/xmpp/error.rs
+++ b/src/xmpp/error.rs
@@ -21,7 +21,7 @@ pub enum XmppClientError {
     BadXml(&'static str),
     BadStream(&'static str),
     IOError(std::io::Error),
-    TlsError(rustls::Error),
+    TlsError(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl Display for XmppClientError {
@@ -36,7 +36,15 @@ impl Display for XmppClientError {
     }
 }
 
-impl Error for XmppClientError {}
+impl Error for XmppClientError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TlsError(e) => Some(e.as_ref()),
+            Self::IOError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
 
 impl From<StreamError> for XmppClientError {
     fn from(err: StreamError) -> Self {
@@ -65,7 +73,7 @@ impl From<std::io::Error> for XmppClientError {
 
 impl From<rustls::Error> for XmppClientError {
     fn from(err: rustls::Error) -> Self {
-        XmppClientError::TlsError(err)
+        XmppClientError::TlsError(Box::new(err))
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 0.7.0

* **Refactor**
  * Updated XmppClientError to handle TLS failures using a boxed trait object, with error details accessible through the standard Error trait.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->